### PR TITLE
Renamed .getPositionFromMatrix() to .setFromMatrixPosition()

### DIFF
--- a/threex.transparency.js
+++ b/threex.transparency.js
@@ -35,7 +35,7 @@ THREEx.Transparency.update	= function(objects, camera){
 		// update the matrixWorld of the object and its children
 		object.updateMatrixWorld()
 		// compute its position in screen space 
-		position.getPositionFromMatrix( object.matrixWorld );
+		position.setFromMatrixPosition( object.matrixWorld );
 		position.applyProjection( screenMatrix );
 		// use the position.x as renderDepth
 		object.renderDepth	= position.z;


### PR DESCRIPTION
THREE.Vector3: .getPositionFromMatrix() has been renamed to .setFromMatrixPosition().

Using .getPositionFromMatrix() works but writes a warning to the console which causes an dramatic performance drop at least on my set up. As far as i remember this changed in r70.